### PR TITLE
Updated a few URLs due to Embedly errors

### DIFF
--- a/top_sites.json
+++ b/top_sites.json
@@ -260,7 +260,7 @@
   },
   {
     "title": "Groupon",
-    "url": "http://www.groupon.com/",
+    "url": "https://www.groupon.com/",
     "image_url": "groupon-com.png",
     "background_color": "#53a318",
     "domain": "groupon.com"
@@ -442,14 +442,14 @@
   },
   {
     "title": "Pinterest",
-    "url": "http://pinterest.com",
+    "url": "https://www.pinterest.com/",
     "image_url": "pinterest-com.png",
     "background_color": "#ba212b",
     "domain": "pinterest.com"
   },
   {
     "title": "Realtor",
-    "url": "http://realtor.com",
+    "url": "http://www.realtor.com/",
     "image_url": "realtor-com.png",
     "background_color": "#fcfcfc",
     "domain": "realtor.com"
@@ -1065,7 +1065,7 @@
   },
   {
     "title": "Delta Air Lines",
-    "url": "http://www.delta.com/",
+    "url": "https://www.delta.com/",
     "image_url": "delta-com.png",
     "background_color": "#F8F9FB",
     "domain": "delta.com"
@@ -1282,7 +1282,7 @@
   },
   {
     "title": "Houzz",
-    "url": "http://houzz.com/",
+    "url": "https://www.houzz.com/",
     "image_url": "houzz-com.png",
     "background_color": null,
     "domain": "houzz.com"


### PR DESCRIPTION
Ref: #23

Current Embedly scraper output:

| `original_url` | `error_message` |
| --- | --- |
| http://ca.gov/ | HTTP 503: Service Unavailable |
| http://netteller.com/ | HTTP 503: Service Unavailable |
| http://www.lowes.com/ | HTTP 403: Forbidden |
| http://www.retailmenot.com/ | HTTP 403: Forbidden |
| http://www.ticketmaster.com/ | HTTP 403: Forbidden |
| https://www.delta.com/ | HTTP 403: Forbidden |
| https://www.houzz.com/ | HTTP 403: Forbidden |
| https://www.pinterest.com/ | HTTP 550: Unknown |
